### PR TITLE
Privacy and Terms Headings Compatibility issue

### DIFF
--- a/src/privacy and terms/privacy-policy.jsx
+++ b/src/privacy and terms/privacy-policy.jsx
@@ -4,7 +4,7 @@ import MetaDecorators from "../MetaDecorator";
 
 function PrivacyPolicy() {
   return (
-    <div className="!w-full prose dark:prose-invert prose-headings:underline m-auto mt-20 md:mt-16 lg:mt-10">
+    <div className="!w-full prose prose-invert prose-headings:underline m-auto mt-20 md:mt-16 lg:mt-10">
       <MetaDecorators
         title="IGTS-NSUT | Privacy & Policy"
         description="Welcome to the official website of the IGTS college society! We are a community of passionate individuals with a shared love for gaming, economics, and math."

--- a/src/privacy and terms/terms.jsx
+++ b/src/privacy and terms/terms.jsx
@@ -4,7 +4,7 @@ import MetaDecorators from "../MetaDecorator";
 
 function Terms() {
   return (
-    <div className="!w-full prose dark:prose-invert prose-headings:underline m-auto mt-20 md:mt-16 lg:mt-10">
+    <div className="!w-full prose prose-invert prose-headings:underline m-auto mt-20 md:mt-16 lg:mt-10">
       <MetaDecorators
         title="IGTS-NSUT | Terms & Conditions"
         description="Welcome to the official website of the IGTS college society! We are a community of passionate individuals with a shared love for gaming, economics, and math."


### PR DESCRIPTION
I have added "prose-invert" class to both "privacy-policy.jsx" and "terms.jsx".

<img width="1440" alt="website" src="https://github.com/IGTS-NSUT-ACCOUNT/front-end-web/assets/124286476/5d542dc9-0bc3-48a5-b90c-5fc5fa407190">
 


